### PR TITLE
Add "frozen in time" banner; accessibility tweaks

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,21 @@
+<header>
+  <div class="flag-container">
+    <a href="https://18f.gsa.gov">
+      <img class="usa-flag" src="{{ site.baseurl }}/img/us_flag_large.png">
+    </a>
+    <p>An official website of the U.S. government</p>
+  </div>
+  <div class="container">
+    <!-- this creates the vertical whitespace in the header -->
+  </div>
+  {% if page.sections %}
+  <nav>
+    <ul class="container">
+    {% for section in page.sections %}
+      <li><a href="#{{ section.id }}">{{ section.title }}</a></li>
+    {% endfor %}
+    </ul>
+  </nav>
+  {% endif %}
+</header>
+

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,9 +8,6 @@
 </div>
 
 <header>
-  <div class="container">
-    <!-- this creates the vertical whitespace in the header -->
-  </div>
   {% if page.sections %}
   <nav>
     <ul class="container">
@@ -21,4 +18,3 @@
   </nav>
   {% endif %}
 </header>
-

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,8 @@
 <div class="container" role="banner">
   <p>
-    <img class="usa-flag" src="{{ site.baseurl }}/img/us_flag_large.png">
-    An official website of the U.S. government
+    An official website of the U.S. government.<br>
+    <strong>This is historical material “frozen in time” on January 20 2017.
+    The website is no longer updated.</strong>
   </p>
 </div>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,10 +1,11 @@
+<div class="container" role="banner">
+  <p>
+    <img class="usa-flag" src="{{ site.baseurl }}/img/us_flag_large.png">
+    An official website of the U.S. government
+  </p>
+</div>
+
 <header>
-  <div class="flag-container">
-    <a href="https://18f.gsa.gov">
-      <img class="usa-flag" src="{{ site.baseurl }}/img/us_flag_large.png">
-    </a>
-    <p>An official website of the U.S. government</p>
-  </div>
   <div class="container">
     <!-- this creates the vertical whitespace in the header -->
   </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,8 +1,9 @@
-<div class="container" role="banner">
+<div id="banner" role="banner">
   <p>
+    <img src="{{ site.baseurl }}/img/us_flag_large.png">
     An official website of the U.S. government.<br>
-    <strong>This is historical material “frozen in time” on January 20 2017.
-    The website is no longer updated.</strong>
+    <strong>This is historical material “frozen in time” on January 20, 2017.
+    This website will no longer be updated.</strong>
   </p>
 </div>
 

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -4,3 +4,5 @@
 {% for script in page.scripts %}
 <script src="{{ site.baseurl }}/js/{{ script }}"></script>
 {% endfor %}
+<!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
+<script async src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NSTC" id="_fed_an_ua_tag"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,35 @@
 
   <body>
 
+    <header>
+      <div class="flag-container">
+        <a href="https://18f.gsa.gov">
+          <img class="usa-flag" src="img/us_flag_large.png">
+        </a>
+        <p>An official website of the U.S. government</p>
+      </div>
+      <div class="container">
+        <!-- this creates the vertical whitespace in the header -->
+      </div>
+      {% if page.sections %}
+      <nav>
+        <ul class="container">
+        {% for section in page.sections %}
+          <li><a href="#{{ section.id }}">{{ section.title }}</a></li>
+        {% endfor %}
+        </ul>
+      </nav>
+      {% endif %}
+    </header>
+
     {{ content }}
+
+    <footer>
+      <div class="container">
+        {% capture footer %}{% include footer.md %}{% endcapture %}
+        {{ footer | markdownify }}
+      </div>
+    </footer>
 
     {% include scripts.html %}
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
     <header>
       <div class="flag-container">
         <a href="https://18f.gsa.gov">
-          <img class="usa-flag" src="img/us_flag_large.png">
+          <img class="usa-flag" src="{{ site.baseurl }}/img/us_flag_large.png">
         </a>
         <p>An official website of the U.S. government</p>
       </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,26 +5,7 @@
 
   <body>
 
-    <header>
-      <div class="flag-container">
-        <a href="https://18f.gsa.gov">
-          <img class="usa-flag" src="{{ site.baseurl }}/img/us_flag_large.png">
-        </a>
-        <p>An official website of the U.S. government</p>
-      </div>
-      <div class="container">
-        <!-- this creates the vertical whitespace in the header -->
-      </div>
-      {% if page.sections %}
-      <nav>
-        <ul class="container">
-        {% for section in page.sections %}
-          <li><a href="#{{ section.id }}">{{ section.title }}</a></li>
-        {% endfor %}
-        </ul>
-      </nav>
-      {% endif %}
-    </header>
+    {% include header.html %}
 
     {{ content }}
 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -108,52 +108,6 @@ header {
       }
     }
   }
-
-  .flag-container {
-    background-color: rgba(46, 154, 196, .8);
-    color: rgba(255, 255, 255, 1);
-    display: flex;
-    flex-direction: row-reverse;
-    justify-content: center;
-    padding: 0.625em 1.875em;
-
-    font-family: Lato, "Helvetica Neue", Helvetica, arial, sans-serif;
-    font-size: 14px;
-    font-weight: 200;
-
-    img {
-      height: 12px;
-      width: 19px;
-    }
-
-    p {
-      font-size: .8em;
-      font-weight: 100;
-      margin: .1em;
-      margin-right: 1em;
-    }
-
-    @media all and (min-width: 1200px) {
-      background-color: transparent;
-      bottom: 2em;
-      position: absolute;
-      right: 2em;
-      z-index: 2;
-
-      img {
-        height: 16px;
-        width: 26px;
-      }
-
-      a:hover + p {
-        visibility: visible;
-      }
-
-      p {
-        visibility: hidden;
-      }
-    }
-  }
 }
 
 nav {

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -60,6 +60,22 @@ h1 {
   margin: 0;
 }
 
+#banner {
+  padding: 1em;
+
+  p {
+    margin: 0 auto;
+    max-width: 800px;
+    position: relative;
+
+    img {
+      position: relative;
+      top: -2px;
+      vertical-align: middle;
+    }
+  }
+}
+
 header {
   background-color: $dark-blue;
   background-image: url(../img/potus.jpg);

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -112,7 +112,7 @@ header {
 
 nav {
   background: #000;
-  background: rgba(46, 154, 196, .8);
+  background: $slighty-transparent-blue;
   position: relative;
 
   @media all and (max-width: $mobile-width) {
@@ -514,13 +514,13 @@ section .container {
 }
 
 footer {
-  background: rgba(46, 154, 196, 1);
+  background: $medium-blue;
   color: $white;
   text-align: center;
 
   a:link,
   a:visited {
-    color: rgba(250, 86, 70, 1);
+    color: $white;
   }
 
   & > a {

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -82,14 +82,11 @@ header {
   background-repeat: no-repeat;
   background-position: center center;
   background-size: cover;
+  padding-top: 0;
   position: relative;
 
-  & > .container {
-    padding: 2em 0;
-
-    @media all and (max-width:$mobile-width) {
-      padding: 0;
-    }
+  @media all and (min-width: ($mobile-width + 1px)) {
+    padding-top: 14em;
   }
 
   h1 {

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -3,10 +3,10 @@ $red: #ef5c49;
 $green: #c2ec70;
 $white: #fff;
 $black: #000;
-$slighty-transparent-blue: transparentize($blue, .07);
 $medium-blue: #017BB3; // flag bar background on smaller devices
 $dark-gray: #374b54;
 $dark-blue: #1d325d;
+$slighty-transparent-blue: transparentize($medium-blue, .2);
 
 $left-gutter: 18rem;
 $right-gutter: $left-gutter;

--- a/css/main.scss
+++ b/css/main.scss
@@ -3,6 +3,4 @@
 ---
 @charset "utf-8";
 
-$grey-color-dark: #eee;
-
 @import "_base";

--- a/index.html
+++ b/index.html
@@ -17,36 +17,6 @@ scripts:
 - main.js
 ---
 
-<!-- - href: https://www.google.com
-  text:
-    primary: View the presentation
-    secondary: Google Slides
-  image:
-    href: /img/report-cover.png
-    alt: report cover -->
-
-<header>
-
-  <div class="flag-container">
-    <a href="https://18f.gsa.gov">
-      <img class="usa-flag" src="img/us_flag_large.png">
-    </a>
-    <p>An official website of the U.S. government</p>
-  </div>
-
-  <div class="container">
-  
-  </div>
-  <nav>
-    <ul class="container">
-    {% for section in page.sections %}
-      <li><a href="#{{ section.id }}">{{ section.title }}</a></li>
-    {% endfor %}
-    </ul>
-  </nav>
-  
-</header>
-
 <main>
   {% for section in page.sections %}
   <section id="{{ section.id }}">
@@ -58,10 +28,3 @@ scripts:
   </section>
   {% endfor %}
 </main>
-
-<footer>
-  <div class="container">
-    {% capture footer %}{% include footer.md %}{% endcapture %}
-    {{ footer | markdownify }}
-  </div>
-</footer>

--- a/index.html
+++ b/index.html
@@ -45,9 +45,6 @@ scripts:
     </ul>
   </nav>
   
-  <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
-<script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NSTC" id="_fed_an_ua_tag"></script>
-  
 </header>
 
 <main>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+
 sections:
 - id: work
   title: About SBST
@@ -7,11 +8,6 @@ sections:
   title: Work
 - id: contact
   title: Contact Us
-
-header_icons:
-  - cloud
-  - sun
-  - graph
 
 scripts:
 - main.js


### PR DESCRIPTION
Per @wslack's request, this adds a banner with the message that the site is "frozen in time" on January 20, 2017. Before:

![image](https://cloud.githubusercontent.com/assets/113896/23774744/06c0b39a-04da-11e7-98da-7114439cfa23.png)

After:

![image](https://cloud.githubusercontent.com/assets/113896/23774769/2a82a27a-04da-11e7-99f1-98da1e479f59.png)

I've made a couple of structural tweaks, fixed some color contrast issues with the nav and footer links, and removed unused CSS along the way.